### PR TITLE
Fix #15 - Cannot find name 'SnapshotStateOptions'

### DIFF
--- a/src/utils/jest-test-result-helper.ts
+++ b/src/utils/jest-test-result-helper.ts
@@ -10,7 +10,8 @@ import {
   makeEmptyAggregatedTestResult,
 } from "@jest/test-result";
 import { SnapshotState } from "jest-snapshot";
-import { SnapshotStateOptions } from "jest-snapshot/build/State";
+
+type SnapshotStateOptions = ConstructorParameters<typeof SnapshotState>[1];
 
 type SnapshotResult = TestResult["snapshot"];
 


### PR DESCRIPTION
Instead of using `import { SnapshotStateOptions } from "jest-snapshot/build/State";`
I'm using `type SnapshotStateOptions = ConstructorParameters<typeof SnapshotState>[1];`