### PR TITLE
docs: suggest better usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ npm i -D mocha-chai-jest-snapshot
 then add it to the test setup:
 
 ```js
-// e.g. setup.js (mocha --file setup.js)
+// e.g. setup.js (mocha --require setup.js)
 const chai = require("chai");
 const { jestSnapshotPlugin } = require("mocha-chai-jest-snapshot");
 
-chai.use(jestSnapshotPlugin());
+export const mochaHooks = {
+  before() {
+    chai.use(jestSnapshotPlugin());
+  }
+}
 ```
 
 enjoy.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import * as chai from "chai";
 import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
 
 export const mochaHooks = {
-  before() {
+  beforeAll() {
     chai.use(jestSnapshotPlugin());
   }
 }
@@ -132,7 +132,7 @@ import {
 import customSerializer = from "...";
 
 export const mochaHooks = {
-  before() {
+  beforeAll() {
     chai.use(jestSnapshotPlugin());
     addSerializer(customSerializer);
   }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ then add it to the test setup:
 
 ```js
 // e.g. setup.js (mocha --require setup.js)
-const chai = require("chai");
-const { jestSnapshotPlugin } = require("mocha-chai-jest-snapshot");
+import * as chai from "chai";
+import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
 
 export const mochaHooks = {
   before() {
@@ -38,7 +38,7 @@ export const mochaHooks = {
 enjoy.
 
 ```js
-const { expect } = require("chai");
+import { expect } import "chai";
 it("foo", function () {
   expect({ foo: "bar" }).toMatchSnapshot();
 });
@@ -87,8 +87,8 @@ npx mocha ... --reporter mocha-chai-jest-snapshot/reporters/spec
 #### jest options (setup)
 
 ```js
-const chai = require("chai");
-const { jestSnapshotPlugin } = require("mocha-chai-jest-snapshot");
+import * as chai from "chai";
+import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
 
 chai.use(
   jestSnapshotPlugin({
@@ -124,22 +124,26 @@ module.exports = {
 #### custom serializer
 
 ```js
-const chai = require("chai");
-const {
+import * as chai from "chai";
+import {
   jestSnapshotPlugin,
   addSerializer,
-} = require("mocha-chai-jest-snapshot");
-const customSerializer = require("...");
+} from "mocha-chai-jest-snapshot";
+import customSerializer = from "...";
 
-chai.use(jestSnapshotPlugin());
-addSerializer(customSerializer);
+export const mochaHooks = {
+  before() {
+    chai.use(jestSnapshotPlugin());
+    addSerializer(customSerializer);
+  }
+}
 ```
 
 or
 
 ```js
-const { expect } = require("chai");
-const customSerializer = require("...");
+import { expect } from "chai";
+import customSerializer from "...";
 
 expect.addSnapshotSerializer(customSerializer);
 ```


### PR DESCRIPTION
This package cannot be imported in a regular setup but a mocha root hook is an alternative to importing in test suites which need it

closes #16